### PR TITLE
Rename `-h-padding` to `-padding-h` due to common convention.

### DIFF
--- a/src/css/helper/var.styl
+++ b/src/css/helper/var.styl
@@ -78,9 +78,9 @@ $msg-box-color-border-warning ?= #ba9552
 /** list **/
 $list-border-radius ?= $border-radius
 $list-item-min-height ?= 44px
-$list-item-v-padding ?= 10px
-$list-item-h-padding ?= $list-item-v-padding
-$list-item-line-height = $list-item-min-height - $list-item-v-padding * 2
+$list-item-padding-v ?= 10px
+$list-item-padding-h ?= $list-item-padding-v
+$list-item-line-height = $list-item-min-height - $list-item-padding-v * 2
 
 
 

--- a/src/css/theme/baixing/btn.styl
+++ b/src/css/theme/baixing/btn.styl
@@ -4,33 +4,33 @@
 /* --------------------------------------------- */
 /** size **/
 $btn-height = 40px
-$btn-h-padding = 5px
+$btn-padding-h = 5px
 $btn-fs = 16px
 
 .cmBtn
 	&
-		padding-left $btn-h-padding
-		padding-right $btn-h-padding
+		padding-left $btn-padding-h
+		padding-right $btn-padding-h
 		line-height-as-height($btn-height)
 		font-size $btn-fs
 	&.cmBtnXSmall
-		padding-left ($btn-h-padding - 2)
-		padding-right ($btn-h-padding - 2)
+		padding-left ($btn-padding-h - 2)
+		padding-right ($btn-padding-h - 2)
 		line-height-as-height($btn-height - 16)
 		font-size ($btn-fs - 4)
 	&.cmBtnSmall
-		padding-left ($btn-h-padding - 1)
-		padding-right ($btn-h-padding - 1)
+		padding-left ($btn-padding-h - 1)
+		padding-right ($btn-padding-h - 1)
 		line-height-as-height($btn-height - 8)
 		font-size ($btn-fs - 2)
 	&.cmBtnLarge
-		padding-left ($btn-h-padding + 2)
-		padding-right ($btn-h-padding + 2)
+		padding-left ($btn-padding-h + 2)
+		padding-right ($btn-padding-h + 2)
 		line-height-as-height($btn-height + 4)
 		font-size ($btn-fs + 2)
 	&.cmBtnXLarge
-		padding-left ($btn-h-padding + 4)
-		padding-right ($btn-h-padding + 4)
+		padding-left ($btn-padding-h + 4)
+		padding-right ($btn-padding-h + 4)
 		line-height-as-height($btn-height + 8)
 		font-size ($btn-fs + 4)
 

--- a/src/css/theme/baixing/grid-list.styl
+++ b/src/css/theme/baixing/grid-list.styl
@@ -6,8 +6,8 @@ ul.cmGridList
 	$-item-height = 50px
 	$-item-padding-v = ($-item-height - $font-size * $line-height-ui) / 2
 	$-item-padding-h = 5px
-	$-item-label-padding-left = $font-size * 1.5 + $page-content-h-padding
-	$-item-label-padding-right = $page-content-h-padding
+	$-item-label-padding-left = $font-size * 1.5 + $page-content-padding-h
+	$-item-label-padding-right = $page-content-padding-h
 	$-item-label-input-offset-top = $font-size * (($line-height-ui - 1) / 2)
 	
 	&

--- a/src/css/theme/baixing/list.styl
+++ b/src/css/theme/baixing/list.styl
@@ -16,7 +16,7 @@ $-sel-list-item-content = 'a, p, div, label'
 		>
 			{$-sel-list-item-content}
 				&:first-child
-					padding $list-item-v-padding $list-item-h-padding
+					padding $list-item-padding-v $list-item-padding-h
 
 
 /* --------------------------------------------- */
@@ -90,7 +90,7 @@ $list-arrow-area-width = 30px
 			top 50%
 			width 0
 			height $list-arrow-height
-			right $list-item-h-padding
+			right $list-item-padding-h
 			pointer-events none
 			html.cmui &
 				content ''
@@ -112,13 +112,13 @@ $list-arrow-area-width = 30px
 		background-color transparent
 		border-style solid
 		border-width $list-arrow-height 0 $list-arrow-height ($list-arrow-height/2)
-		right $list-item-h-padding - 2px
+		right $list-item-padding-h - 2px
 		transform none
 */
 
 /* --------------------------------------------- */
 /** badge **/
-$list-badge-h-padding = 5px
+$list-badge-padding-h = 5px
 $list-badge-height = 22px
 $list-badge-min-width = 30px
 $list-badge-max-width = 45px
@@ -127,10 +127,10 @@ $list-badge-bg-color = $color-fg-minor
 .cmList > li[data-badge]::after
 	content attr(data-badge)
 	box-sizing border-box
-	absolute top 50% right $list-item-h-padding
+	absolute top 50% right $list-item-padding-h
 	z-index 20
 	margin-top (- $list-badge-height/2)
-	padding 0 $list-badge-h-padding
+	padding 0 $list-badge-padding-h
 	min-width $list-badge-min-width
 	max-width $list-badge-max-width
 	overflow ellipsis
@@ -160,7 +160,7 @@ $list-value-fg-color = $color-fg-minor
 	absolute top 50% right 0
 	z-index 20
 	margin-top (- $list-value-height/2)
-	padding-right $list-item-h-padding
+	padding-right $list-item-padding-h
 	line-height-as-height($list-value-height)
 	max-width $list-value-width
 	overflow ellipsis
@@ -184,7 +184,7 @@ $list-value-fg-color = $color-fg-minor
 .cmList > li[data-badge] >
 	{$-sel-list-item-content}
 		&:first-child
-			padding-right ($list-item-h-padding + $list-badge-max-width + 5)
+			padding-right ($list-item-padding-h + $list-badge-max-width + 5)
 .cmList > li[data-badge].cmRightArrow,
 .cmList.cmRightArrow > li[data-badge]
 	> a:first-child
@@ -198,18 +198,18 @@ $list-value-fg-color = $color-fg-minor
 
 /* --------------------------------------------- */
 /** icon **/
-$list-item-icon-h-margin = $list-item-v-padding
+$list-item-icon-margin-h = $list-item-padding-v
 
 .cmList > li >
 	{$-sel-list-item-content}
 		&:first-child
 			> .cmIcon
 				float left
-				margin-right $list-item-icon-h-margin
+				margin-right $list-item-icon-margin-h
 
 				for $size in 2 .. 5
 					&.cmX{$size}0
-						$list-item-icon-v-margin = (($list-item-line-height - $size * 10)/2)
-						margin-top $list-item-icon-v-margin
-						margin-bottom $list-item-icon-v-margin
+						$list-item-icon-margin-v = (($list-item-line-height - $size * 10)/2)
+						margin-top $list-item-icon-margin-v
+						margin-bottom $list-item-icon-margin-v
 

--- a/src/css/theme/baixing/page.styl
+++ b/src/css/theme/baixing/page.styl
@@ -46,7 +46,7 @@
 
 /* --------------------------------------------- */
 /** nav bar btn **/
-$nav-bar-btn-h-padding = 7px
+$nav-bar-btn-padding-h = 7px
 
 $nav-bar-btn-color-fg = $color-fg
 $nav-bar-btn-color-bg = darken($btn-color-bg, 10%)
@@ -57,8 +57,8 @@ $nav-bar-btn-color-bg-info = #b0bcc4
 .cmNavBar .cmBtn
 	height $nav-bar-btn-height
 	line-height $nav-bar-btn-height
-	padding-left $nav-bar-btn-h-padding
-	padding-right $nav-bar-btn-h-padding
+	padding-left $nav-bar-btn-padding-h
+	padding-right $nav-bar-btn-padding-h
 	font-size $bx-fs-text-minor
 	border-radius $nav-bar-btn-br
 	&.cmBtnBack
@@ -143,8 +143,8 @@ $nav-bar-btn-color-bg-info = #b0bcc4
 /* --------------------------------------------- */
 /** main content **/
 .cmSubview > main
-	padding-left $page-content-h-padding
-	padding-right $page-content-h-padding
+	padding-left $page-content-padding-h
+	padding-right $page-content-padding-h
 	min-height 200px
 	clearfix()
 
@@ -152,5 +152,5 @@ $nav-bar-btn-color-bg-info = #b0bcc4
 full-width-block()
 	display block
 	box-sizing border-box
-	margin-left (- $page-content-h-padding)
-	margin-right (- $page-content-h-padding)
+	margin-left (- $page-content-padding-h)
+	margin-right (- $page-content-padding-h)

--- a/src/css/theme/baixing/text-style.styl
+++ b/src/css/theme/baixing/text-style.styl
@@ -81,13 +81,13 @@ bx-text-minor()
 /* --------------------------------------------- */
 /** label **/
 $label-border-radius = 0.25em
-$label-h-padding = 0.25em
-$label-v-padding = 0.20em
+$label-padding-h = 0.25em
+$label-padding-v = 0.20em
 
 $label-bg-color = #ffb380
 $label-bg-color-success = #98d374
 .cmLabel
-	padding $label-v-padding $label-h-padding
+	padding $label-padding-v $label-padding-h
 	font-weight inherit
 	white-space nowrap
 	color white
@@ -101,13 +101,13 @@ $label-bg-color-success = #98d374
 /** info box **/
 $info-box-color-bg = $bx-color-x-light-gray
 $info-box-color-border = $bx-color-light-gray
-$info-box-h-padding = $page-content-h-padding
-$info-box-v-padding = 10px
+$info-box-padding-h = $page-content-padding-h
+$info-box-padding-v = 10px
 $info-box-border-radius = $border-radius
 .cmInfoBox
 	margin-top 10px
 	margin-bottom 10px
-	padding $info-box-v-padding $info-box-h-padding
+	padding $info-box-padding-v $info-box-padding-h
 	background-color $info-box-color-bg
 	border 1px solid $info-box-color-border
 	border-radius $info-box-border-radius

--- a/src/css/theme/baixing/var.styl
+++ b/src/css/theme/baixing/var.styl
@@ -57,7 +57,7 @@ $nav-bar-btn-height = 28px
 $nav-bar-btn-br = 5px
 
 //content
-$page-content-h-padding = 10px
+$page-content-padding-h = 10px
 
 
 /* --------------------------------------------- */
@@ -76,5 +76,5 @@ $msg-box-color-bg-warning = #fff7db
 /* --------------------------------------------- */
 /** list **/
 $list-item-min-height = 50px
-$list-item-h-padding = 15px
+$list-item-padding-h = 15px
 


### PR DESCRIPTION
`-h(v)-padding(margin)` → `-padding(margin)-h(v)`。

这样更接近 CSS 属性的命名规律，比如 `margin-left` 这样。