### PR TITLE
Add `scrollBox` module.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ const scripts = {
 		'./src/js/overlay-mask.js',
 		'./src/js/overlay-loading.js',
 		'./src/js/panel.js',
+		'./src/js/scroll-box.js',
 		'./src/js/adapter-trad/_outro.js',
 	]
 }

--- a/src/css/core/common.styl
+++ b/src/css/core/common.styl
@@ -39,8 +39,8 @@
 	a[data-action]
 		-webkit-touch-callout none
 
-	// TODO: auto apply ScrollFix to these elemets.
-	.cm-scrollable-content
+	// scroll-box
+	.cm-scroll-box
 		overflow-x hidden
 		overflow-y auto
 		-webkit-overflow-scrolling touch

--- a/src/js/scroll-box.js
+++ b/src/js/scroll-box.js
@@ -1,0 +1,80 @@
+////////////////////  scroll box  ////////////////////
+
+void function (window, CMUI) {
+	'use strict'
+
+	// namespace
+	var moduleName = 'scrollBox'
+	var module = CMUI[moduleName] = CMUI[moduleName] || {}
+
+	// const
+	var CLS = 'cm-scroll-box'
+
+	// Inspired by [ScrollFix](https://github.com/joelambert/ScrollFix)
+	function _initWrapper($wrapper) {
+		if (!$wrapper.length) return
+
+		// Handle the start of interactions
+		$wrapper.on('touchstart', function () {
+			var elem = this
+			var startTopScroll = elem.scrollTop
+
+			if (startTopScroll <= 0) {
+				elem.scrollTop = 1
+			} else if (startTopScroll + elem.offsetHeight >= elem.scrollHeight) {
+				elem.scrollTop = elem.scrollHeight - elem.offsetHeight - 1
+			}
+		})
+
+		// auto align to boundary if edge offset less than 2px.
+		$wrapper.on('click', function () {
+			var elem = this
+			var startTopScroll = elem.scrollTop
+
+			if (startTopScroll && startTopScroll < 3) {
+				elem.scrollTop = 0
+			} else if (startTopScroll + elem.offsetHeight > elem.scrollHeight - 3) {
+				elem.scrollTop = elem.scrollHeight - elem.offsetHeight
+			}
+		})
+
+		// disable touchmove event when content is too short, restore when content is long enough
+		$wrapper.on('touchstart', function () {
+			var elem = this
+			if (elem.offsetHeight >= elem.scrollHeight) {
+				this.addEventListener('touchmove', disableEvent, false)
+			} else {
+				this.removeEventListener('touchmove', disableEvent, false)
+			}
+
+			function disableEvent(ev) {
+				ev.preventDefault()
+			}
+		})
+
+		// use this property to mark handled wrapper
+		$wrapper[0].scrollBoxReady = true
+	}
+
+	function refresh() {
+		var $wrappers = $('.' + CLS)
+		$wrappers.each(function () {
+			if (!this.scrollBoxReady) {
+				var $wrapper = $(this)
+				_initWrapper($wrapper)
+			}
+		})
+	}
+
+	function _init() {
+		refresh()
+	}
+
+	//exports
+	module._init = _init
+	module.refresh = refresh
+
+	//init
+	CMUI._initModule(moduleName)
+
+}(window, CMUI)


### PR DESCRIPTION
#### 概述

scrollBox 是一个轻量级的区域滚动解决方案，基于：

* `overflow-y: auto;` —— 按需自动出现滚动条
* `-webkit-overflow-scrolling: touch;` —— 惯性滚动与回弹
* [ScrollFix](https://github.com/joelambert/ScrollFix) —— 修复一些交互上的问题

还增强了以下优化：

* 点击内容后自动修复 ScrollFix 产生的 1px 偏移
* 当内容过短时触摸移动不会拖动整个页面

#### 如何使用

* 给需要增加区域滚动能力的容器加上 `.cm-scroll-box` 类。
* CMUI 会自己初始化所有 `.cm-scroll-box` 元素；但由 JS 动态生成的 `.cm-scroll-box` 元素需要手动初始化，每次执行 `CMUI.scrollBox.refresh()` 即可。