### PR TITLE
Fix mask shrinking behavior.

### DIFF
--- a/dist/cmui.js
+++ b/dist/cmui.js
@@ -257,6 +257,8 @@ void function (window, CMUI) {
 	var CLS_FADE_OUT = 'fade-out'
 	var HTML = '<div class="' + CLS + ' ' + CLS_HIDDEN + '"></div>'
 
+	var FADEOUT_DURATION = 200
+
 	var $elem
 	var isVisible = false
 
@@ -272,9 +274,12 @@ void function (window, CMUI) {
 
 	function _pos() {
 		// first, shrink
-		$elem.css('height', '100%')
+		_shrink()
 		// then, reset its height.
 		$elem.css('height', document.documentElement.scrollHeight + 'px')
+	}
+	function _shrink() {
+		$elem.css('height', '100%')
 	}
 
 	//api
@@ -302,12 +307,16 @@ void function (window, CMUI) {
 		if (!isVisible) return false
 		var classNames = [CLS, CLS_HIDDEN]
 		$elem.attr('class', classNames.join(' '))
+		_shrink()
 		isVisible = false
 	}
 	function fadeOut() {
 		if (!isVisible) return false
 		var classNames = [CLS, CLS_FADE_OUT]
 		$elem.attr('class', classNames.join(' '))
+		setTimeout(() => {
+			if (!isVisible) _shrink()
+		}, FADEOUT_DURATION)
 		isVisible = false
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "http://cmui.net/",
   "repository": "CMUI/CMUI",
   "author": "cssmagic <cssmagic.cn@gmail.com>",

--- a/src/js/overlay-mask.js
+++ b/src/js/overlay-mask.js
@@ -14,6 +14,8 @@ void function (window, CMUI) {
 	var CLS_FADE_OUT = 'fade-out'
 	var HTML = '<div class="' + CLS + ' ' + CLS_HIDDEN + '"></div>'
 
+	var FADEOUT_DURATION = 200
+
 	var $elem
 	var isVisible = false
 
@@ -29,9 +31,12 @@ void function (window, CMUI) {
 
 	function _pos() {
 		// first, shrink
-		$elem.css('height', '100%')
+		_shrink()
 		// then, reset its height.
 		$elem.css('height', document.documentElement.scrollHeight + 'px')
+	}
+	function _shrink() {
+		$elem.css('height', '100%')
 	}
 
 	//api
@@ -59,12 +64,16 @@ void function (window, CMUI) {
 		if (!isVisible) return false
 		var classNames = [CLS, CLS_HIDDEN]
 		$elem.attr('class', classNames.join(' '))
+		_shrink()
 		isVisible = false
 	}
 	function fadeOut() {
 		if (!isVisible) return false
 		var classNames = [CLS, CLS_FADE_OUT]
 		$elem.attr('class', classNames.join(' '))
+		setTimeout(() => {
+			if (!isVisible) _shrink()
+		}, FADEOUT_DURATION)
 		isVisible = false
 	}
 


### PR DESCRIPTION
修复如下问题：

当 mask 关闭时，高度并不会自动收缩。如果此时页面内容的高度缩短，由于 mask 撑着（虽然看不见），页面整体高度并不会收缩。